### PR TITLE
fix: update deploy.sh to use npm instead of yarn

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,7 @@
 set -e
 
 # build
-yarn build
+npm run build
 
 # navigate into the build output directory
 cd dist


### PR DESCRIPTION
- Replace 'yarn build' with 'npm run build' in deploy script
- Ensures consistency with npm package manager migration