### PR TITLE
feat(portfolio): add accessible screenshot carousel for mobile projects

### DIFF
--- a/src/components/AppIcon.vue
+++ b/src/components/AppIcon.vue
@@ -23,6 +23,8 @@ import IconBriefcase from '~icons/fa6-solid/briefcase'
 import IconCalendarDays from '~icons/fa6-solid/calendar-days'
 import IconCertificate from '~icons/fa6-solid/certificate'
 import IconChartLine from '~icons/fa6-solid/chart-line'
+import IconChevronLeft from '~icons/fa6-solid/chevron-left'
+import IconChevronRight from '~icons/fa6-solid/chevron-right'
 import IconCircleCheck from '~icons/fa6-solid/circle-check'
 import IconCircleUp from '~icons/fa6-solid/circle-up'
 import IconCode from '~icons/fa6-solid/code'
@@ -58,6 +60,8 @@ const ICONS = {
   'fas/calendar-alt': IconCalendarDays,
   'fas/certificate': IconCertificate,
   'fas/chart-line': IconChartLine,
+  'fas/chevron-left': IconChevronLeft,
+  'fas/chevron-right': IconChevronRight,
   'fas/check-circle': IconCircleCheck,
   'fas/code': IconCode,
   'fas/database': IconDatabase,

--- a/src/components/Portfolio.vue
+++ b/src/components/Portfolio.vue
@@ -29,30 +29,13 @@
 
         <p class="portfolio-card-description">{{ project.description }}</p>
 
-        <ul
+        <portfolio-screenshot-gallery
           v-if="project.screenshots && project.screenshots.length"
-          class="portfolio-screenshots"
-          :class="`portfolio-screenshots--${project.type === 'mobile' ? 'mobile' : 'desktop'}`"
+          :project-name="project.name"
+          :project-type="project.type"
+          :screenshots="getResolvedScreenshots(project.screenshots)"
           :aria-label="$t('portfolio.screenshots', { name: project.name })"
-        >
-          <li
-            v-for="(screenshot, screenshotIndex) in project.screenshots"
-            :key="`${project.name}-${screenshotIndex}`"
-            class="portfolio-screenshot"
-          >
-            <figure class="portfolio-screenshot-frame">
-              <img
-                :src="getScreenshotSrc(screenshot.src)"
-                :alt="screenshot.alt"
-                class="portfolio-screenshot-image"
-                width="360"
-                height="780"
-                loading="lazy"
-                decoding="async"
-              />
-            </figure>
-          </li>
-        </ul>
+        />
 
         <div
           v-if="getCaseStudyFields(project).length"
@@ -146,6 +129,7 @@
 
 <script>
 import { getPortfolioProjects } from '@/i18n/content'
+import PortfolioScreenshotGallery from '@/components/PortfolioScreenshotGallery.vue'
 
 const screenshotModules = import.meta.glob('@/assets/img/portfolio/*.{png,jpg,jpeg,webp}', {
   eager: true,
@@ -159,6 +143,9 @@ const screenshotWebpModules = import.meta.glob('@/assets/img/portfolio/*.webp', 
 
 export default {
   name: 'Portfolio',
+  components: {
+    PortfolioScreenshotGallery,
+  },
   data() {
     return {
       caseStudyFields: [
@@ -193,6 +180,12 @@ export default {
       const match = Object.entries(screenshotModules).find(([path]) => path.endsWith(`/${filename}`))
       if (match) return match[1]
       return `${import.meta.env.BASE_URL}img/${filename}`
+    },
+    getResolvedScreenshots(screenshots) {
+      return screenshots.map((screenshot) => ({
+        alt: screenshot.alt,
+        src: this.getScreenshotSrc(screenshot.src),
+      }))
     },
   },
 }
@@ -324,51 +317,6 @@ export default {
   flex: 1;
 }
 
-.portfolio-screenshots {
-  display: grid;
-  gap: var(--space-lg);
-  margin: var(--space-sm) 0 var(--space-md);
-  list-style: none;
-  padding: 0;
-}
-
-.portfolio-screenshot {
-  min-width: 0;
-}
-
-.portfolio-screenshot-frame {
-  margin: 0;
-  overflow: hidden;
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-md);
-  background: var(--bg-secondary);
-}
-
-.portfolio-screenshot-image {
-  display: block;
-  width: 100%;
-  height: auto;
-  object-fit: cover;
-  object-position: top center;
-}
-
-.portfolio-screenshots--mobile .portfolio-screenshot-image {
-  aspect-ratio: 9 / 19.5;
-}
-
-.portfolio-screenshots--desktop .portfolio-screenshot-image {
-  aspect-ratio: 16 / 9;
-}
-
-.portfolio-screenshots--mobile {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.portfolio-screenshots--desktop {
-  grid-template-columns: 1fr;
-}
-
 .portfolio-case-study {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
@@ -477,16 +425,6 @@ export default {
   .portfolio-featured,
   .portfolio-grid {
     grid-template-columns: 1fr;
-  }
-
-  .portfolio-screenshots--mobile {
-    grid-template-columns: 1fr;
-  }
-
-  .portfolio-screenshots--mobile .portfolio-screenshot-image,
-  .portfolio-screenshots--desktop .portfolio-screenshot-image {
-    aspect-ratio: auto;
-    object-fit: contain;
   }
 
   .portfolio-card {

--- a/src/components/PortfolioScreenshotGallery.vue
+++ b/src/components/PortfolioScreenshotGallery.vue
@@ -1,0 +1,288 @@
+<template>
+  <div
+    class="portfolio-screenshots-gallery"
+    :class="{
+      'portfolio-screenshots-gallery--mobile': projectType === 'mobile',
+      'portfolio-screenshots-gallery--multi': screenshots.length > 1,
+    }"
+  >
+    <ul
+      ref="track"
+      class="portfolio-screenshots"
+      :class="`portfolio-screenshots--${projectType === 'mobile' ? 'mobile' : 'desktop'}`"
+      :aria-label="ariaLabel"
+      @scroll.passive="updateActiveIndex"
+    >
+      <li
+        v-for="(screenshot, screenshotIndex) in screenshots"
+        :key="`${projectName}-${screenshotIndex}`"
+        class="portfolio-screenshot"
+      >
+        <figure class="portfolio-screenshot-frame">
+          <img
+            :src="screenshot.src"
+            :alt="screenshot.alt"
+            class="portfolio-screenshot-image"
+            width="360"
+            height="780"
+            loading="lazy"
+            decoding="async"
+          />
+        </figure>
+      </li>
+    </ul>
+
+    <div
+      v-if="showCarouselControls"
+      class="portfolio-screenshots-controls"
+      role="group"
+      :aria-label="$t('portfolio.screenshotControls', { name: projectName })"
+    >
+      <button
+        type="button"
+        class="portfolio-screenshots-nav"
+        :disabled="activeIndex === 0"
+        :aria-label="$t('portfolio.previousScreenshot')"
+        @click="goToSlide(activeIndex - 1)"
+      >
+        <app-icon :icon="['fas', 'chevron-left']" aria-hidden="true" />
+      </button>
+
+      <div class="portfolio-screenshots-dots">
+        <button
+          v-for="(_, dotIndex) in screenshots"
+          :key="`${projectName}-dot-${dotIndex}`"
+          type="button"
+          class="portfolio-screenshots-dot"
+          :class="{ 'portfolio-screenshots-dot--active': dotIndex === activeIndex }"
+          :aria-label="$t('portfolio.goToScreenshot', {
+            current: dotIndex + 1,
+            total: screenshots.length,
+          })"
+          :aria-current="dotIndex === activeIndex ? 'true' : undefined"
+          @click="goToSlide(dotIndex)"
+        />
+      </div>
+
+      <button
+        type="button"
+        class="portfolio-screenshots-nav"
+        :disabled="activeIndex === screenshots.length - 1"
+        :aria-label="$t('portfolio.nextScreenshot')"
+        @click="goToSlide(activeIndex + 1)"
+      >
+        <app-icon :icon="['fas', 'chevron-right']" aria-hidden="true" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'PortfolioScreenshotGallery',
+  props: {
+    projectName: {
+      type: String,
+      required: true,
+    },
+    projectType: {
+      type: String,
+      default: 'desktop',
+    },
+    screenshots: {
+      type: Array,
+      required: true,
+    },
+    ariaLabel: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      activeIndex: 0,
+    }
+  },
+  computed: {
+    showCarouselControls() {
+      return this.projectType === 'mobile' && this.screenshots.length > 1
+    },
+  },
+  methods: {
+    updateActiveIndex() {
+      const track = this.$refs.track
+      if (!track) return
+
+      const slideWidth = track.clientWidth
+      if (!slideWidth) return
+
+      this.activeIndex = Math.min(
+        this.screenshots.length - 1,
+        Math.round(track.scrollLeft / slideWidth),
+      )
+    },
+    goToSlide(index) {
+      const track = this.$refs.track
+      if (!track || index < 0 || index >= this.screenshots.length) return
+
+      const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ? 'auto'
+        : 'smooth'
+
+      track.scrollTo({
+        left: index * track.clientWidth,
+        behavior,
+      })
+      this.activeIndex = index
+    },
+  },
+}
+</script>
+
+<style scoped>
+.portfolio-screenshots {
+  display: grid;
+  gap: var(--space-lg);
+  margin: var(--space-sm) 0 var(--space-md);
+  list-style: none;
+  padding: 0;
+}
+
+.portfolio-screenshot {
+  min-width: 0;
+}
+
+.portfolio-screenshot-frame {
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  background: var(--bg-secondary);
+}
+
+.portfolio-screenshot-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  object-position: top center;
+}
+
+.portfolio-screenshots--mobile .portfolio-screenshot-image {
+  aspect-ratio: 9 / 19.5;
+}
+
+.portfolio-screenshots--desktop .portfolio-screenshot-image {
+  aspect-ratio: 16 / 9;
+}
+
+.portfolio-screenshots--mobile {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.portfolio-screenshots--desktop {
+  grid-template-columns: 1fr;
+}
+
+.portfolio-screenshots-controls {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  margin: var(--space-md) 0 var(--space-md);
+}
+
+.portfolio-screenshots-nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.portfolio-screenshots-nav:hover:not(:disabled) {
+  background: var(--bg-secondary);
+  border-color: color-mix(in srgb, var(--primary-color) 35%, var(--border-color));
+  color: var(--primary-color);
+}
+
+.portfolio-screenshots-nav:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.portfolio-screenshots-nav svg {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.portfolio-screenshots-dots {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.portfolio-screenshots-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-muted) 45%, transparent);
+  cursor: pointer;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.portfolio-screenshots-dot--active {
+  background: var(--primary-color);
+  transform: scale(1.15);
+}
+
+.portfolio-screenshots-dot:hover {
+  background: color-mix(in srgb, var(--primary-color) 70%, var(--text-muted));
+}
+
+@media (max-width: 768px) {
+  .portfolio-screenshots-gallery--mobile.portfolio-screenshots-gallery--multi .portfolio-screenshots {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    margin-bottom: var(--space-sm);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .portfolio-screenshots-gallery--mobile.portfolio-screenshots-gallery--multi .portfolio-screenshots {
+      scroll-behavior: smooth;
+    }
+  }
+
+  .portfolio-screenshots-gallery--mobile.portfolio-screenshots-gallery--multi .portfolio-screenshots::-webkit-scrollbar {
+    display: none;
+  }
+
+  .portfolio-screenshots-gallery--mobile.portfolio-screenshots-gallery--multi .portfolio-screenshot {
+    flex: 0 0 100%;
+    scroll-snap-align: center;
+  }
+
+  .portfolio-screenshots-gallery--mobile.portfolio-screenshots-gallery--multi .portfolio-screenshot-image,
+  .portfolio-screenshots--desktop .portfolio-screenshot-image {
+    aspect-ratio: auto;
+    object-fit: contain;
+  }
+
+  .portfolio-screenshots-gallery--mobile.portfolio-screenshots-gallery--multi .portfolio-screenshots-controls {
+    display: flex;
+  }
+}
+</style>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -138,6 +138,10 @@
     "technologies": "Technologies",
     "visitProject": "Visit {name}",
     "screenshots": "{name} screenshots",
+    "screenshotControls": "{name} screenshot navigation",
+    "previousScreenshot": "Previous screenshot",
+    "nextScreenshot": "Next screenshot",
+    "goToScreenshot": "Go to screenshot {current} of {total}",
     "infrastructure": "Side projects and renderlog.dev run on a Raspberry Pi 5 at home, exposed through Cloudflare Tunnel.",
     "types": {
       "mobile": "Mobile app",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -138,6 +138,10 @@
     "technologies": "Tecnologías",
     "visitProject": "Visitar {name}",
     "screenshots": "Capturas de {name}",
+    "screenshotControls": "Navegación de capturas de {name}",
+    "previousScreenshot": "Captura anterior",
+    "nextScreenshot": "Captura siguiente",
+    "goToScreenshot": "Ir a la captura {current} de {total}",
     "infrastructure": "Los proyectos personales y renderlog.dev corren en una Raspberry Pi 5 en casa, expuestos con Cloudflare Tunnel.",
     "types": {
       "mobile": "App móvil",


### PR DESCRIPTION
## Summary

Mobile portfolio case studies with multiple screenshots now use a dedicated carousel instead of a cramped three-column grid on small viewports. Screenshot navigation is keyboard-friendly and includes bilingual labels for prev/next, dot indicators, and reduced-motion support.

## Changes Made

- Extract screenshot rendering into `PortfolioScreenshotGallery.vue` with swipe, dot, and chevron controls
- Wire the gallery into `Portfolio.vue` and resolve screenshot URLs via a shared helper
- Add chevron-left/right icons to `AppIcon.vue`
- Add EN/ES i18n strings for screenshot navigation controls

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Accessibility improvement
- [x] Code refactoring

## Testing

- [x] Tested locally
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Tested in production-like environment

### Test Steps

1. Open the Portfolio section on a viewport ≤768px
2. Find a mobile project with multiple screenshots (e.g. Ciudadano USA)
3. Swipe or use prev/next buttons and dot indicators to navigate screenshots
4. Confirm controls are disabled at the first/last slide and labels read correctly in EN and ES

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Test plan

- [x] `npm run test:run` (193 tests passed)
- [x] `npm run lint:check`
- [x] `npm run build`
- [ ] Manual check: mobile carousel swipe and keyboard navigation on a mobile project card


Made with [Cursor](https://cursor.com)