### PR TITLE
fix(hero): compact mobile portrait for above-the-fold value prop

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -686,6 +686,12 @@ a:focus-visible {
   }
 }
 
+@media (max-width: 540px) {
+  .hero {
+    padding: 1.5rem 0 0;
+  }
+}
+
 /* Utility Classes */
 .text-center { text-align: center; }
 .text-left { text-align: left; }

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -309,6 +309,27 @@ export default {
 }
 
 @media (max-width: 540px) {
+  .hero-portrait {
+    max-width: 240px;
+    margin-bottom: 1.25rem;
+  }
+
+  .hero-avatar {
+    height: min(38vh, 260px);
+    object-position: center 22%;
+  }
+
+  .portrait-tag {
+    display: none;
+  }
+
+  .portrait-rule {
+    top: -12px;
+    right: -12px;
+    width: 48px;
+    height: 48px;
+  }
+
   .hero-actions {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary

On mobile (e.g. Galaxy S24), the hero portrait consumed ~55–60% of the viewport and pushed the positioning line, description, and CTAs below the fold. This PR compacts the portrait on small screens so recruiters see the senior value proposition without scrolling.

## Changes Made

- Reduce hero portrait to `max-width: 240px` and cap height at `min(38vh, 260px)` on viewports ≤ 540px
- Crop portrait with `object-position: center 22%` to keep the face visible
- Hide the redundant "Broken Arrow · Bilingüe" overlay tag on small screens (availability chip below already signals intent)
- Scale down the decorative L-rule accent proportionally
- Reduce hero top padding from `3rem` to `1.5rem` on small screens

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility improvement
- [x] Style/formatting changes

## Testing

- [x] Tested locally
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Tested in production-like environment

### Test Steps

1. Open the site on a phone or DevTools device emulation (≤ 540px width, e.g. Galaxy S24)
2. Confirm the hero shows: compact portrait, availability chip, full name, subtitle, and at least one CTA without scrolling
3. Verify desktop/tablet layout (≥ 541px) is unchanged

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test plan

- [x] `npm run test:run` (184 tests passed)
- [x] `npm run build`
- [x] `npm run lint:check`


Made with [Cursor](https://cursor.com)