### PR TITLE
feat(a11y): improve keyboard navigation, focus management, and landmarks

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,0 +1,90 @@
+# Accessibility
+
+## Goal
+
+Make the portfolio comfortable to navigate with a keyboard, predictable for screen reader users, and covered by automated tests that catch regressions in the app shell, navigation, and interactive components.
+
+## Implemented Baseline
+
+- The skip link is the first focusable control and targets `#main-content`.
+- The main landmark is programmatically focusable so skip-link activation moves focus reliably.
+- The mobile menu opens as a modal dialog, moves focus to the close button, traps `Tab` and `Shift+Tab`, closes on `Escape`, and restores focus to the menu button.
+- Active navigation items expose `aria-current="location"`.
+- Assistive labels live in `src/i18n/locales/en.json` and `src/i18n/locales/es.json`.
+- The hero is a labelled section inside `main`, not a nested page banner.
+- Experience roles use headings under the section heading.
+- Reduced-motion users get instant section scrolling and immediate focus timing.
+- App shell, drawer, skip link, focus management, language toggle, screenshot gallery, and key components are covered by Vitest and jest-axe.
+
+## Screen Reader Contract
+
+The expected high-level page outline is:
+
+1. Skip link to main content.
+2. Main navigation with brand, section links, language controls, theme switch, and mobile menu trigger.
+3. Main landmark with a single `h1`, followed by labelled portfolio sections.
+4. Contact closing section with contact actions.
+5. Contentinfo footer.
+
+Interactive controls should announce their purpose, state, and destination without requiring visual context.
+
+Approximate English screen-reader flow:
+
+```text
+Link: Skip to main content
+Navigation landmark: Main navigation
+Button: Open mobile menu, collapsed
+Link: Go to about section, Wilberto Pacheco
+Links: Impact, Products, Experience, Skills, Process, Contact
+Group: Toggle language
+Button: ES - Switch to Spanish
+Button: EN - Switch to English, pressed
+Switch: Switch to Dark Mode, off
+Main landmark
+Heading level 1: Wilberto Pacheco Batista
+Region: Call to action
+Links: View professional impact, Let's talk, Download Resume
+Region: Social media links
+Links: Visit LinkedIn profile, Visit GitHub profile, Visit X profile
+Regions: Results with impact, What I've built, Professional trajectory, Technical capabilities, How I work, Education and certifications
+Contentinfo
+```
+
+## Keyboard Contract
+
+- `Tab` starts on the skip link, then moves through navigation controls and page actions in visual order.
+- `Enter` on the skip link moves focus to the main landmark.
+- `Enter` or `Space` on the mobile menu button opens the drawer.
+- When the drawer opens, focus moves into it.
+- `Tab` and `Shift+Tab` cycle inside the drawer until it closes.
+- `Escape` closes the drawer and returns focus to the menu button.
+
+## Automated Coverage
+
+- `tests/unit/App.spec.js`: skip link, main landmark, footer, single `h1`, locale sync, and app-level axe.
+- `tests/unit/Navigation.spec.js`: drawer open/close, focus entry, focus trap, Escape focus return, `aria-current`, and axe.
+- `tests/unit/MobileMenuDrawer.spec.js`: dialog semantics, inner mobile navigation, active link state, and axe.
+- `tests/unit/composables/useMobileMenu.spec.js`: scroll lock, outside click, Escape, focus entry, and tab trap.
+- `tests/unit/composables/useSectionScroll.spec.js`: fixed-nav scroll offset, heading focus, and reduced-motion behavior.
+- `tests/unit/LanguageToggle.spec.js`: labelled language controls, pressed state, keyboard focus, and axe.
+- `tests/unit/PortfolioScreenshotGallery.spec.js`: labelled screenshots, carousel controls, disabled states, active dot state, and axe.
+
+## Manual QA Checklist
+
+- Navigate from page load with only `Tab`, `Shift+Tab`, `Enter`, `Space`, and `Escape`.
+- Confirm the skip link appears on focus and moves focus to the main landmark.
+- Open the mobile menu at a narrow viewport and verify focus stays inside the drawer until close.
+- Confirm the current section is announced as current by a screen reader.
+- Toggle language and verify `document.documentElement.lang` and accessible labels change.
+- Enable reduced motion and verify section navigation does not animate.
+- Run a spot check with VoiceOver, NVDA, or another screen reader for the main outline and drawer behavior.
+
+## Validation
+
+Run these commands before handoff:
+
+```sh
+npm run test:run
+npm run build
+npm run lint:check
+```

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,13 @@
 <template>
   <div id="app" itemscope itemtype="https://schema.org/Person">
     <!-- Skip to main content link for accessibility -->
-    <a href="#main-content" class="skip-link">{{ $t('accessibility.skipToContent') }}</a>
+    <a href="#main-content" class="skip-link" @click="focusMainContent">{{ $t('accessibility.skipToContent') }}</a>
     
     <!-- Navigation -->
     <Navigation />
     
     <!-- Main Content -->
-    <main id="main-content" class="main-content" role="main">
+    <main id="main-content" class="main-content" role="main" tabindex="-1">
       <section
         v-for="section in pageSections"
         :key="section.id"
@@ -84,6 +84,11 @@ export default {
         ? 'Wilberto Pacheco Batista - Software Engineer de Producto y Modernización'
         : 'Wilberto Pacheco Batista - Product-Minded Software Engineer'
       document.title = title
+    },
+    focusMainContent() {
+      this.$nextTick(() => {
+        document.getElementById('main-content')?.focus({ preventScroll: true })
+      })
     }
   },
   watch: {
@@ -136,12 +141,6 @@ export default {
   html {
     scroll-behavior: smooth;
   }
-}
-
-/* Focus styles for accessibility */
-*:focus {
-  outline: 2px solid var(--primary-color);
-  outline-offset: 2px;
 }
 
 /* Print styles */

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -107,7 +107,7 @@
   top: -40px;
   left: 6px;
   background: var(--primary-color);
-  color: white;
+  color: #ffffff;
   padding: 8px;
   text-decoration: none;
   border-radius: var(--radius-md);
@@ -117,6 +117,14 @@
 
 .skip-link:focus {
   top: 6px;
+}
+
+a.skip-link:focus-visible {
+  color: #ffffff;
+  text-decoration: none;
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--primary-color);
 }
 
 /* Base Styles */
@@ -194,14 +202,14 @@ p {
   color: var(--text-secondary);
 }
 
-/* Links — exclude .btn so global hover color does not override button text */
-a:not(.btn) {
+/* Links — exclude .btn and .skip-link so global color does not override button/skip text */
+a:not(.btn):not(.skip-link) {
   color: var(--primary-color);
   text-decoration: none;
   transition: color var(--transition-fast);
 }
 
-a:not(.btn):hover {
+a:not(.btn):not(.skip-link):hover {
   color: var(--primary-dark);
 }
 

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="hero" role="banner" aria-labelledby="hero-title">
+  <section class="hero" aria-labelledby="hero-title">
     <div class="container">
       <div class="hero-grid">
         <div class="hero-text">
@@ -23,7 +23,7 @@
 
           <!-- Call to Action -->
           <div class="hero-actions" role="region" aria-labelledby="actions-heading">
-            <h2 id="actions-heading" class="sr-only">Call to Action</h2>
+            <h2 id="actions-heading" class="sr-only">{{ $t('accessibility.callToAction') }}</h2>
             <a
               href="#impact"
               class="btn btn-primary"
@@ -57,14 +57,14 @@
 
           <!-- Social Links -->
           <div class="social-links" role="region" aria-labelledby="social-heading">
-            <h2 id="social-heading" class="sr-only">Social Media Links</h2>
+            <h2 id="social-heading" class="sr-only">{{ $t('accessibility.socialLinks') }}</h2>
             <a
               href="https://www.linkedin.com/in/wilberto-pacheco-batista/"
               class="social-link"
               title="LinkedIn"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Visit LinkedIn profile"
+              :aria-label="$t('accessibility.visitLinkedInProfile')"
               @click="track('social_click', { network: 'linkedin' })"
             >
               <app-icon :icon="['fab', 'linkedin']" aria-hidden="true" />
@@ -75,7 +75,7 @@
               title="GitHub"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Visit GitHub profile"
+              :aria-label="$t('accessibility.visitGitHubProfile')"
               @click="track('social_click', { network: 'github' })"
             >
               <app-icon :icon="['fab', 'github']" aria-hidden="true" />
@@ -86,7 +86,7 @@
               title="X (Twitter)"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Visit X (Twitter) profile"
+              :aria-label="$t('accessibility.visitXProfile')"
               @click="track('social_click', { network: 'x' })"
             >
               <app-icon :icon="['fab', 'x-twitter']" aria-hidden="true" />

--- a/src/components/Credentials.vue
+++ b/src/components/Credentials.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cred-grid" role="region" :aria-label="$t('sections.credentials.title')">
+  <div class="cred-grid">
     <!-- Column A: education + languages -->
     <div class="cred-col">
       <section class="cred-card" :aria-labelledby="'credentials-education-heading'">

--- a/src/components/Experience.vue
+++ b/src/components/Experience.vue
@@ -13,7 +13,7 @@
         </div>
 
         <div class="role-main">
-          <div class="role-pos">{{ job.position }}</div>
+          <h3 class="role-pos">{{ job.position }}</h3>
           <p v-if="job.summary" class="role-summary">{{ job.summary }}</p>
 
           <div v-if="job.scopeTags && job.scopeTags.length" class="role-scope">

--- a/src/components/LanguageToggle.vue
+++ b/src/components/LanguageToggle.vue
@@ -9,6 +9,7 @@
       class="language-option"
       :class="{ 'language-option--active': currentLocale === 'es' }"
       :aria-pressed="currentLocale === 'es'"
+      :aria-label="$t('accessibility.switchToSpanish')"
       @click="setLocale('es')"
     >
       ES
@@ -18,6 +19,7 @@
       class="language-option"
       :class="{ 'language-option--active': currentLocale === 'en' }"
       :aria-pressed="currentLocale === 'en'"
+      :aria-label="$t('accessibility.switchToEnglish')"
       @click="setLocale('en')"
     >
       EN

--- a/src/components/MobileMenuDrawer.vue
+++ b/src/components/MobileMenuDrawer.vue
@@ -10,10 +10,12 @@
     </Transition>
 
     <Transition name="mm-slide">
-      <aside
+      <div
         v-if="open"
         id="mobile-menu"
         class="mobile-menu-drawer"
+        role="dialog"
+        aria-modal="true"
         :aria-label="$t('accessibility.mobileNavigation')"
       >
         <div class="mm-header">
@@ -21,6 +23,7 @@
           <button
             type="button"
             class="mm-close"
+            data-autofocus
             :aria-label="$t('accessibility.closeMenu')"
             @click="$emit('close')"
           >
@@ -29,13 +32,14 @@
           </button>
         </div>
 
-        <nav class="mm-nav">
+        <nav class="mm-nav" :aria-label="$t('accessibility.mobileNavigation')">
           <a
             v-for="item in items"
             :key="item.id"
             :href="'#' + item.id"
             class="mm-link"
             :class="{ active: activeSection === item.id }"
+            :aria-current="activeSection === item.id ? 'location' : undefined"
             @click.prevent="$emit('navigate', item.id)"
           >
             <span class="mm-icon" aria-hidden="true">
@@ -57,7 +61,7 @@
             {{ $t('hero.downloadResume') }}
           </a>
         </div>
-      </aside>
+      </div>
     </Transition>
   </Teleport>
 </template>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -3,7 +3,7 @@
     class="navbar"
     :class="{ 'navbar-scrolled': isScrolled }"
     role="navigation"
-    aria-label="Main navigation"
+    :aria-label="$t('accessibility.mainNavigation')"
   >
     <div class="navbar-container">
       <button
@@ -21,7 +21,7 @@
         <span></span>
       </button>
 
-      <a href="#about" class="navbar-brand" aria-label="Go to about section">
+      <a href="#about" class="navbar-brand" :aria-label="$t('accessibility.goToAbout')">
         <span class="brand-main">Wilberto Pacheco</span>
         <span class="brand-suffix" aria-hidden="true">// SWE</span>
       </a>
@@ -36,6 +36,7 @@
             :href="'#' + item.id"
             class="nav-link"
             :class="{ active: activeSection === item.id }"
+            :aria-current="activeSection === item.id ? 'location' : undefined"
             @click="scrollToSection(item.id)"
           >
             {{ navLabel(item.id) }}
@@ -113,7 +114,7 @@ const {
   isMobileMenuOpen,
   toggleMobileMenu,
   closeMobileMenu,
-  handleEscape,
+  handleMenuKeydown,
 } = useMobileMenu()
 
 const menuToggleLabel = computed(() =>
@@ -129,11 +130,13 @@ const themeToggleLabel = computed(() =>
 )
 
 const goToSection = (sectionId) => {
-  navigateAfterClose(sectionId, closeMobileMenu)
+  navigateAfterClose(sectionId, () => closeMobileMenu({ restoreFocus: false }))
 }
 
 const handleKeydown = (event) => {
-  handleEscape(event)
+  if (handleMenuKeydown(event)) {
+    return
+  }
 
   if ((event.ctrlKey || event.metaKey) && event.key === 't') {
     event.preventDefault()

--- a/src/composables/useMobileMenu.js
+++ b/src/composables/useMobileMenu.js
@@ -1,21 +1,74 @@
-import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import { nextTick, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 
 /**
  * Mobile drawer open state, scroll lock, and dismiss handlers.
  */
 export function useMobileMenu() {
   const isMobileMenuOpen = ref(false)
+  const restoreFocusTarget = ref(null)
+
+  const focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'textarea:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',')
+
+  const getDrawer = () => document.getElementById('mobile-menu')
+
+  const getFocusableDrawerElements = () => {
+    const drawer = getDrawer()
+    return drawer
+      ? [...drawer.querySelectorAll(focusableSelector)].filter((element) => !element.hasAttribute('disabled'))
+      : []
+  }
+
+  const focusFirstDrawerControl = () => {
+    const [firstFocusable] = getFocusableDrawerElements()
+    firstFocusable?.focus({ preventScroll: true })
+  }
+
+  const restoreFocus = () => {
+    const target = restoreFocusTarget.value || document.querySelector('.mobile-menu-toggle')
+    target?.focus?.()
+    restoreFocusTarget.value = null
+  }
 
   watch(isMobileMenuOpen, (open) => {
     document.body.style.overflow = open ? 'hidden' : ''
+
+    if (open) {
+      nextTick(() => {
+        const scheduleFocus = window.requestAnimationFrame || window.setTimeout
+        scheduleFocus(focusFirstDrawerControl)
+      })
+    }
   })
 
   const toggleMobileMenu = () => {
-    isMobileMenuOpen.value = !isMobileMenuOpen.value
+    if (isMobileMenuOpen.value) {
+      closeMobileMenu()
+      return
+    }
+
+    restoreFocusTarget.value = document.activeElement === document.body
+      ? null
+      : document.activeElement
+    isMobileMenuOpen.value = true
   }
 
-  const closeMobileMenu = () => {
+  const closeMobileMenu = ({ restoreFocus: shouldRestoreFocus = true } = {}) => {
+    if (!isMobileMenuOpen.value) {
+      return
+    }
+
     isMobileMenuOpen.value = false
+
+    if (shouldRestoreFocus) {
+      restoreFocus()
+    }
   }
 
   const handleClickOutside = (event) => {
@@ -32,13 +85,51 @@ export function useMobileMenu() {
 
   const handleEscape = (event) => {
     if (event.key !== 'Escape' || !isMobileMenuOpen.value) {
-      return
+      return false
     }
 
     closeMobileMenu()
+    return true
+  }
 
-    const toggleButton = document.querySelector('.mobile-menu-toggle')
-    toggleButton?.focus()
+  const trapDrawerFocus = (event) => {
+    if (event.key !== 'Tab' || !isMobileMenuOpen.value) {
+      return false
+    }
+
+    const focusableElements = getFocusableDrawerElements()
+    if (!focusableElements.length) {
+      event.preventDefault()
+      return true
+    }
+
+    const firstFocusable = focusableElements[0]
+    const lastFocusable = focusableElements[focusableElements.length - 1]
+    const activeElement = document.activeElement
+
+    if (!getDrawer()?.contains(activeElement)) {
+      event.preventDefault()
+      firstFocusable.focus()
+      return true
+    }
+
+    if (event.shiftKey && activeElement === firstFocusable) {
+      event.preventDefault()
+      lastFocusable.focus()
+      return true
+    }
+
+    if (!event.shiftKey && activeElement === lastFocusable) {
+      event.preventDefault()
+      firstFocusable.focus()
+      return true
+    }
+
+    return false
+  }
+
+  const handleMenuKeydown = (event) => {
+    return handleEscape(event) || trapDrawerFocus(event)
   }
 
   onMounted(() => {
@@ -55,5 +146,6 @@ export function useMobileMenu() {
     toggleMobileMenu,
     closeMobileMenu,
     handleEscape,
+    handleMenuKeydown,
   }
 }

--- a/src/composables/useSectionScroll.js
+++ b/src/composables/useSectionScroll.js
@@ -23,9 +23,11 @@ export function useSectionScroll(invalidateSectionCache) {
       section.querySelector('.section-header, .hero-content, h1, h2') || section
     const top = scrollTarget.getBoundingClientRect().top + window.pageYOffset - offset
 
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
     window.scrollTo({
       top: Math.max(0, top),
-      behavior: 'smooth',
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
     })
 
     const focusTarget =
@@ -34,9 +36,7 @@ export function useSectionScroll(invalidateSectionCache) {
       focusTarget.setAttribute('tabindex', '-1')
     }
 
-    const focusDelay = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-      ? 0
-      : 500
+    const focusDelay = prefersReducedMotion ? 0 : 500
 
     setTimeout(() => {
       focusTarget.focus({ preventScroll: true })

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -82,12 +82,21 @@
   },
   "accessibility": {
     "skipToContent": "Skip to main content",
+    "mainNavigation": "Main navigation",
+    "goToAbout": "Go to about section",
     "darkMode": "Switch to Dark Mode",
     "lightMode": "Switch to Light Mode",
     "openMenu": "Open mobile menu",
     "closeMenu": "Close mobile menu",
     "mobileNavigation": "Mobile navigation",
-    "languageToggle": "Toggle language"
+    "languageToggle": "Toggle language",
+    "switchToSpanish": "ES - Switch to Spanish",
+    "switchToEnglish": "EN - Switch to English",
+    "callToAction": "Call to action",
+    "socialLinks": "Social media links",
+    "visitLinkedInProfile": "Visit LinkedIn profile",
+    "visitGitHubProfile": "Visit GitHub profile",
+    "visitXProfile": "Visit X profile"
   },
   "contact": {
     "email": "Email",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -82,12 +82,21 @@
   },
   "accessibility": {
     "skipToContent": "Saltar al contenido principal",
+    "mainNavigation": "Navegación principal",
+    "goToAbout": "Ir a la sección de inicio",
     "darkMode": "Cambiar a modo oscuro",
     "lightMode": "Cambiar a modo claro",
     "openMenu": "Abrir menú móvil",
     "closeMenu": "Cerrar menú móvil",
     "mobileNavigation": "Navegación móvil",
-    "languageToggle": "Cambiar idioma"
+    "languageToggle": "Cambiar idioma",
+    "switchToSpanish": "ES - Cambiar a español",
+    "switchToEnglish": "EN - Cambiar a inglés",
+    "callToAction": "Llamado a la acción",
+    "socialLinks": "Enlaces de redes sociales",
+    "visitLinkedInProfile": "Visitar perfil de LinkedIn",
+    "visitGitHubProfile": "Visitar perfil de GitHub",
+    "visitXProfile": "Visitar perfil de X"
   },
   "contact": {
     "email": "Correo electrónico",

--- a/tests/unit/About.spec.js
+++ b/tests/unit/About.spec.js
@@ -24,6 +24,13 @@ const createTestI18n = (locale = 'en') => {
         },
         contact: {
           letsTalk: "Let's talk"
+        },
+        accessibility: {
+          callToAction: 'Call to action',
+          socialLinks: 'Social media links',
+          visitLinkedInProfile: 'Visit LinkedIn profile',
+          visitGitHubProfile: 'Visit GitHub profile',
+          visitXProfile: 'Visit X profile',
         }
       },
       es: {
@@ -40,6 +47,13 @@ const createTestI18n = (locale = 'en') => {
         },
         contact: {
           letsTalk: 'Hablemos'
+        },
+        accessibility: {
+          callToAction: 'Llamado a la acción',
+          socialLinks: 'Enlaces de redes sociales',
+          visitLinkedInProfile: 'Visitar perfil de LinkedIn',
+          visitGitHubProfile: 'Visitar perfil de GitHub',
+          visitXProfile: 'Visitar perfil de X',
         }
       }
     }
@@ -112,7 +126,7 @@ describe('About.vue', () => {
     })
     expect(screen.getByRole('link', { name: /LinkedIn/ })).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /GitHub/ })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /X \(Twitter\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /X profile/ })).toBeInTheDocument()
   })
 
   it('renders the primary call to action buttons', () => {
@@ -146,8 +160,7 @@ describe('About.vue', () => {
         plugins: [i18n]
       }
     })
-    const section = screen.getByRole('banner')
-    expect(section).toBeInTheDocument()
+    const section = document.querySelector('.hero')
     expect(section).toHaveAttribute('aria-labelledby', 'hero-title')
     
     const title = screen.getByRole('heading', { level: 1 })
@@ -161,7 +174,6 @@ describe('About.vue', () => {
         plugins: [i18n]
       }
     })
-    expect(screen.getByRole('banner')).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
     expect(screen.getAllByRole('heading', { level: 2 }).length).toBeGreaterThan(0)
   })

--- a/tests/unit/App.spec.js
+++ b/tests/unit/App.spec.js
@@ -1,0 +1,76 @@
+import { render, screen, fireEvent } from '@testing-library/vue'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { axe } from 'jest-axe'
+import App from '@/App.vue'
+import en from '@/i18n/locales/en.json'
+import es from '@/i18n/locales/es.json'
+
+const createTestI18n = (locale = 'en') => createI18n({
+  legacy: false,
+  locale,
+  fallbackLocale: 'en',
+  globalInjection: true,
+  messages: { en, es },
+})
+
+const renderApp = (locale = 'en') => render(App, {
+  global: {
+    plugins: [createTestI18n(locale)],
+  },
+})
+
+describe('App.vue', () => {
+  beforeEach(() => {
+    localStorage.getItem.mockReturnValue(null)
+    document.documentElement.lang = 'en'
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('renders the skip link and main landmark', () => {
+    renderApp()
+
+    const skipLink = screen.getByRole('link', { name: 'Skip to main content' })
+    const main = screen.getByRole('main')
+
+    expect(skipLink).toHaveAttribute('href', '#main-content')
+    expect(main).toHaveAttribute('id', 'main-content')
+    expect(main).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('moves focus to main content when the skip link is activated', async () => {
+    renderApp()
+
+    await fireEvent.click(screen.getByRole('link', { name: 'Skip to main content' }))
+
+    expect(screen.getByRole('main')).toHaveFocus()
+  })
+
+  it('exposes the primary page landmarks and one h1', () => {
+    renderApp()
+
+    expect(screen.getByRole('navigation', { name: 'Main navigation' })).toBeInTheDocument()
+    expect(screen.getByRole('main')).toBeInTheDocument()
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument()
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1)
+  })
+
+  it('syncs the document language and title from the active locale', () => {
+    localStorage.getItem.mockImplementation((key) => (key === 'locale' ? 'es' : null))
+    renderApp('es')
+
+    expect(document.documentElement.lang).toBe('es')
+    expect(document.title).toBe('Wilberto Pacheco Batista - Software Engineer de Producto y Modernización')
+  })
+
+  it('should have no accessibility violations', async () => {
+    const { container } = renderApp()
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+

--- a/tests/unit/Credentials.spec.js
+++ b/tests/unit/Credentials.spec.js
@@ -66,7 +66,7 @@ describe('Credentials.vue', () => {
       },
     })
 
-    expect(screen.getByRole('region', { name: 'Education and certifications' })).toBeInTheDocument()
+    expect(screen.getByText('Education')).toBeInTheDocument()
     expect(screen.getByText('Computer Science Engineer')).toBeInTheDocument()
     expect(screen.getByText('University of Informatic Sciences · 2005 - 2010')).toBeInTheDocument()
     expect(screen.getByText(/Native Spanish and professional \/ bilingual English/)).toBeInTheDocument()

--- a/tests/unit/LanguageToggle.spec.js
+++ b/tests/unit/LanguageToggle.spec.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/vue'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { createI18n } from 'vue-i18n'
+import { axe } from 'jest-axe'
 import LanguageToggle from '@/components/LanguageToggle.vue'
 
 const createTestI18n = (locale = 'en') => {
@@ -11,11 +12,15 @@ const createTestI18n = (locale = 'en') => {
       en: {
         accessibility: {
           languageToggle: 'Toggle language',
+          switchToSpanish: 'ES - Switch to Spanish',
+          switchToEnglish: 'EN - Switch to English',
         },
       },
       es: {
         accessibility: {
           languageToggle: 'Cambiar idioma',
+          switchToSpanish: 'ES - Cambiar a español',
+          switchToEnglish: 'EN - Cambiar a inglés',
         },
       },
     },
@@ -39,8 +44,8 @@ describe('LanguageToggle.vue', () => {
     })
 
     expect(screen.getByRole('group', { name: 'Toggle language' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'ES' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'EN' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'ES - Switch to Spanish' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'EN - Switch to English' })).toBeInTheDocument()
   })
 
   it('marks EN as active when locale is English', () => {
@@ -50,8 +55,8 @@ describe('LanguageToggle.vue', () => {
       },
     })
 
-    expect(screen.getByRole('button', { name: 'EN' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'ES' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: 'EN - Switch to English' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'ES - Switch to Spanish' })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('marks ES as active when locale is Spanish', () => {
@@ -62,8 +67,8 @@ describe('LanguageToggle.vue', () => {
       },
     })
 
-    expect(screen.getByRole('button', { name: 'ES' })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: 'EN' })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: 'ES - Cambiar a español' })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: 'EN - Cambiar a inglés' })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('switches locale when ES is clicked', async () => {
@@ -73,7 +78,7 @@ describe('LanguageToggle.vue', () => {
       },
     })
 
-    await fireEvent.click(screen.getByRole('button', { name: 'ES' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'ES - Switch to Spanish' }))
 
     expect(i18n.global.locale.value).toBe('es')
     expect(document.documentElement.lang).toBe('es')
@@ -87,7 +92,7 @@ describe('LanguageToggle.vue', () => {
       },
     })
 
-    await fireEvent.click(screen.getByRole('button', { name: 'EN' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'EN - Cambiar a inglés' }))
 
     expect(spanishI18n.global.locale.value).toBe('en')
     expect(document.documentElement.lang).toBe('en')
@@ -100,8 +105,19 @@ describe('LanguageToggle.vue', () => {
       },
     })
 
-    const englishButton = screen.getByRole('button', { name: 'EN' })
+    const englishButton = screen.getByRole('button', { name: 'EN - Switch to English' })
     englishButton.focus()
     expect(englishButton).toHaveFocus()
+  })
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(LanguageToggle, {
+      global: {
+        plugins: [i18n],
+      },
+    })
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 })

--- a/tests/unit/MobileMenuDrawer.spec.js
+++ b/tests/unit/MobileMenuDrawer.spec.js
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/vue'
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { createI18n } from 'vue-i18n'
+import { axe } from 'jest-axe'
 import MobileMenuDrawer from '@/components/MobileMenuDrawer.vue'
 import { NAV_ITEMS, PRIMARY_NAV_IDS } from '@/config/sections'
 import { getPublicAssetUrl, RESUME_FILENAME } from '@/utils/public-assets'
@@ -62,7 +63,8 @@ describe('MobileMenuDrawer.vue', () => {
   it('renders drawer navigation when open', () => {
     renderDrawer()
 
-    expect(screen.getByRole('complementary', { name: 'Mobile navigation' })).toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Mobile navigation' })).toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: 'Mobile navigation' })).toBeInTheDocument()
     expect(document.querySelectorAll('.mm-nav .mm-link')).toHaveLength(navItems.length)
     expect(screen.getByText('Process')).toBeInTheDocument()
   })
@@ -79,6 +81,7 @@ describe('MobileMenuDrawer.vue', () => {
 
     const activeLink = document.querySelector('.mm-link[href="#howIWork"]')
     expect(activeLink).toHaveClass('active')
+    expect(activeLink).toHaveAttribute('aria-current', 'location')
   })
 
   it('renders the resume download action', () => {
@@ -106,5 +109,12 @@ describe('MobileMenuDrawer.vue', () => {
     await fireEvent.click(document.querySelector('.mm-link[href="#skills"]'))
 
     expect(emitted().navigate).toEqual([['skills']])
+  })
+
+  it('should have no accessibility violations when open', async () => {
+    renderDrawer()
+
+    const results = await axe(document.body)
+    expect(results).toHaveNoViolations()
   })
 })

--- a/tests/unit/Navigation.spec.js
+++ b/tests/unit/Navigation.spec.js
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/vue'
+import userEvent from '@testing-library/user-event'
 import { mount, flushPromises } from '@vue/test-utils'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { createI18n } from 'vue-i18n'
@@ -33,12 +34,16 @@ const createTestI18n = (locale = 'en') => {
           downloadResume: 'Download Resume'
         },
         accessibility: {
+          mainNavigation: 'Main navigation',
+          goToAbout: 'Go to about section',
           lightMode: 'Switch to Light Mode',
           darkMode: 'Switch to Dark Mode',
           openMenu: 'Open mobile menu',
           closeMenu: 'Close mobile menu',
           mobileNavigation: 'Mobile navigation',
-          languageToggle: 'Toggle language'
+          languageToggle: 'Toggle language',
+          switchToSpanish: 'ES - Switch to Spanish',
+          switchToEnglish: 'EN - Switch to English'
         }
       },
       es: {
@@ -63,12 +68,16 @@ const createTestI18n = (locale = 'en') => {
           downloadResume: 'Descargar CV'
         },
         accessibility: {
+          mainNavigation: 'Navegación principal',
+          goToAbout: 'Ir a la sección de inicio',
           lightMode: 'Cambiar a Modo Claro',
           darkMode: 'Cambiar a Modo Oscuro',
           openMenu: 'Abrir menú móvil',
           closeMenu: 'Cerrar menú móvil',
           mobileNavigation: 'Navegación móvil',
-          languageToggle: 'Cambiar idioma'
+          languageToggle: 'Cambiar idioma',
+          switchToSpanish: 'ES - Cambiar a español',
+          switchToEnglish: 'EN - Cambiar a inglés'
         }
       }
     }
@@ -247,7 +256,7 @@ describe('Navigation.vue', () => {
       expect(toggle).toHaveAttribute('aria-expanded', 'true')
       expect(document.body.style.overflow).toBe('hidden')
       expect(document.querySelector('.mobile-menu-drawer')).toBeTruthy()
-      expect(screen.getByRole('complementary', { name: 'Mobile navigation' })).toBeInTheDocument()
+      expect(screen.getByRole('dialog', { name: 'Mobile navigation' })).toBeInTheDocument()
 
       await fireEvent.click(toggle)
       expect(toggle).toHaveAttribute('aria-expanded', 'false')
@@ -284,6 +293,34 @@ describe('Navigation.vue', () => {
 
       expect(toggle).toHaveAttribute('aria-expanded', 'false')
       expect(focusSpy).toHaveBeenCalled()
+    })
+
+    it('moves focus into the drawer when it opens', async () => {
+      renderNavigation()
+      await fireEvent.click(getMobileToggle())
+
+      await vi.waitFor(() => {
+        expect(document.querySelector('.mm-close')).toHaveFocus()
+      })
+    })
+
+    it('traps Tab and Shift+Tab inside the open drawer', async () => {
+      const user = userEvent.setup()
+      renderNavigation()
+      await fireEvent.click(getMobileToggle())
+
+      const closeButton = document.querySelector('.mm-close')
+      const resumeLink = document.querySelector('.mm-resume-btn')
+
+      await vi.waitFor(() => {
+        expect(closeButton).toHaveFocus()
+      })
+
+      await user.keyboard('{Shift>}{Tab}{/Shift}')
+      expect(resumeLink).toHaveFocus()
+
+      await user.tab()
+      expect(closeButton).toHaveFocus()
     })
 
     it('closes the drawer when clicking outside the drawer and toggle', async () => {
@@ -363,6 +400,7 @@ describe('Navigation.vue', () => {
 
       await vi.waitFor(() => {
         expect(getDesktopNavLink('experience')).toHaveClass('active')
+        expect(getDesktopNavLink('experience')).toHaveAttribute('aria-current', 'location')
       })
     })
 

--- a/tests/unit/PortfolioScreenshotGallery.spec.js
+++ b/tests/unit/PortfolioScreenshotGallery.spec.js
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/vue'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { axe } from 'jest-axe'
+import PortfolioScreenshotGallery from '@/components/PortfolioScreenshotGallery.vue'
+
+const screenshots = [
+  {
+    src: 'portfolio/ciudadanousa-home.webp',
+    alt: 'CiudadanoUSA home screen',
+  },
+  {
+    src: 'portfolio/ciudadanousa-n400.webp',
+    alt: 'CiudadanoUSA N-400 screen',
+  },
+]
+
+const createTestI18n = () => createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      portfolio: {
+        screenshotControls: '{name} screenshot navigation',
+        previousScreenshot: 'Previous screenshot',
+        nextScreenshot: 'Next screenshot',
+        goToScreenshot: 'Go to screenshot {current} of {total}',
+      },
+    },
+  },
+})
+
+const renderGallery = (props = {}) => render(PortfolioScreenshotGallery, {
+  props: {
+    projectName: 'CiudadanoUSA',
+    projectType: 'mobile',
+    screenshots,
+    ariaLabel: 'CiudadanoUSA screenshots',
+    ...props,
+  },
+  global: {
+    plugins: [createTestI18n()],
+  },
+})
+
+describe('PortfolioScreenshotGallery.vue', () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollTo = vi.fn()
+  })
+
+  it('labels the screenshot list and images', () => {
+    renderGallery()
+
+    expect(screen.getByLabelText('CiudadanoUSA screenshots')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'CiudadanoUSA home screen' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'CiudadanoUSA N-400 screen' })).toBeInTheDocument()
+  })
+
+  it('exposes carousel controls for multi-screenshot mobile projects', async () => {
+    renderGallery()
+    Object.defineProperty(screen.getByLabelText('CiudadanoUSA screenshots'), 'clientWidth', {
+      configurable: true,
+      value: 320,
+    })
+
+    expect(screen.getByRole('group', { name: 'CiudadanoUSA screenshot navigation' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Previous screenshot' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Go to screenshot 1 of 2' })).toHaveAttribute('aria-current', 'true')
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Go to screenshot 2 of 2' }))
+
+    expect(screen.getByRole('button', { name: 'Go to screenshot 2 of 2' })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('button', { name: 'Next screenshot' })).toBeDisabled()
+  })
+
+  it('does not render carousel controls for single screenshots', () => {
+    renderGallery({ screenshots: screenshots.slice(0, 1) })
+
+    expect(screen.queryByRole('group', { name: 'CiudadanoUSA screenshot navigation' })).not.toBeInTheDocument()
+  })
+
+  it('should have no accessibility violations', async () => {
+    const { container } = renderGallery()
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+

--- a/tests/unit/composables/useMobileMenu.spec.js
+++ b/tests/unit/composables/useMobileMenu.spec.js
@@ -8,7 +8,11 @@ describe('useMobileMenu', () => {
     document.body.style.overflow = ''
     document.body.innerHTML = `
       <button class="mobile-menu-toggle"></button>
-      <aside class="mobile-menu-drawer"></aside>
+      <aside id="mobile-menu" class="mobile-menu-drawer">
+        <button class="mm-close">Close</button>
+        <a href="#impact" class="mm-link">Impact</a>
+        <a href="/resume.pdf" class="mm-resume-btn">Resume</a>
+      </aside>
     `
   })
 
@@ -80,6 +84,41 @@ describe('useMobileMenu', () => {
 
     expect(result.isMobileMenuOpen.value).toBe(false)
     expect(focusSpy).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('moves focus to the first drawer control when opened', async () => {
+    const { result, wrapper } = withSetup(useMobileMenu)
+
+    result.toggleMobileMenu()
+    await flushPromises()
+    await new Promise((resolve) => window.requestAnimationFrame(resolve))
+
+    expect(document.querySelector('.mm-close')).toHaveFocus()
+
+    wrapper.unmount()
+  })
+
+  it('traps Tab focus inside the drawer', () => {
+    const { result, wrapper } = withSetup(useMobileMenu)
+    const closeButton = document.querySelector('.mm-close')
+    const resumeLink = document.querySelector('.mm-resume-btn')
+
+    result.toggleMobileMenu()
+    closeButton.focus()
+
+    const shiftTab = { key: 'Tab', shiftKey: true, preventDefault: vi.fn() }
+    result.handleMenuKeydown(shiftTab)
+
+    expect(shiftTab.preventDefault).toHaveBeenCalled()
+    expect(resumeLink).toHaveFocus()
+
+    const tab = { key: 'Tab', shiftKey: false, preventDefault: vi.fn() }
+    result.handleMenuKeydown(tab)
+
+    expect(tab.preventDefault).toHaveBeenCalled()
+    expect(closeButton).toHaveFocus()
 
     wrapper.unmount()
   })

--- a/tests/unit/composables/useSectionScroll.spec.js
+++ b/tests/unit/composables/useSectionScroll.spec.js
@@ -72,6 +72,39 @@ describe('useSectionScroll', () => {
     wrapper.unmount()
   })
 
+  it('uses instant scroll and focus timing when reduced motion is preferred', () => {
+    vi.useFakeTimers()
+    window.matchMedia.mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    const scrollTo = vi.fn()
+    vi.stubGlobal('scrollTo', scrollTo)
+    const invalidateSectionCache = vi.fn()
+
+    const { result, wrapper } = withSetup(useSectionScroll, invalidateSectionCache)
+    const heading = document.getElementById('experience-heading')
+    const focusSpy = vi.spyOn(heading, 'focus')
+
+    result.scrollToSection('experience')
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 136,
+      behavior: 'auto',
+    })
+
+    vi.runAllTimers()
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+
+    wrapper.unmount()
+  })
+
   it('closes the mobile menu before navigating', async () => {
     vi.useFakeTimers()
     const scrollTo = vi.fn()


### PR DESCRIPTION
## Summary

Strengthens portfolio accessibility with keyboard-first navigation, proper focus management, and clearer ARIA semantics across navigation, the mobile drawer, and section landmarks.

## Changes Made

- Move skip-link focus to `#main-content` and make the main landmark programmatically focusable
- Convert mobile drawer to a modal dialog with focus trap, initial focus, and optional focus restore
- Localize accessibility labels (nav, social links, language toggle) in ES/EN
- Add `aria-current="location"` on active nav links and semantic `h3` for job titles
- Remove redundant landmark roles and global `*:focus` override (handled in shared CSS)
- Add `docs/ACCESSIBILITY.md` documenting patterns and testing approach
- Expand unit tests with jest-axe coverage and focus-trap behavior

## Type of Change

- [x] Accessibility improvement
- [x] Documentation update

## Testing

- [x] Tested locally
- [x] Added unit tests

### Test plan

- [x] `npm run test:run` (200 tests passed)
- [x] `npm run lint:check`
- [x] `npm run build`
- [ ] Tab through desktop nav and confirm active link has `aria-current`
- [ ] Open mobile drawer: focus lands on close button; Tab/Shift+Tab stay inside drawer
- [ ] Activate skip link: focus moves to main content without scrolling
- [ ] Switch language: accessibility labels update in ES/EN

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Made with [Cursor](https://cursor.com)