### PR TITLE
fix(experience): stack role metadata vertically on mobile

### DIFF
--- a/src/components/Experience.vue
+++ b/src/components/Experience.vue
@@ -201,13 +201,12 @@ export default {
 
   .role-aside {
     display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 0.375rem 0.875rem;
+    flex-direction: column;
+    gap: 0.375rem;
   }
 
   .role-company {
-    margin-top: 0;
+    margin-top: 0.25rem;
   }
 
   .role-loc {


### PR DESCRIPTION
## Summary

On viewports ≤980px, the experience timeline role metadata (period, company, location) now stacks in a vertical column instead of wrapping inline. This improves readability when the layout collapses to a single column.

## Changes Made

- Switch `.role-aside` from row wrap to `flex-direction: column` at the ≤980px breakpoint
- Adjust `.role-company` top margin for consistent spacing in the stacked layout

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Style/formatting changes

## Testing

- [x] Tested locally
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] Tested in production-like environment

### Test Steps

1. Open the site and navigate to the Experience section
2. Resize the viewport to ≤980px (or use mobile device emulation)
3. Confirm period, company, and location stack vertically with clear spacing

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published


Made with [Cursor](https://cursor.com)