### PR TITLE
fix(seo): stop service worker from hijacking sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,7 +4,7 @@
   <!-- Homepage - single-page app -->
   <url>
     <loc>https://wilbertopachecob.github.io/portafolio/</loc>
-    <lastmod>2026-02-14</lastmod>
+    <lastmod>2026-07-29</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
     <xhtml:link rel="alternate" hreflang="en" href="https://wilbertopachecob.github.io/portafolio/"/>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,10 @@
 // Service Worker for Portfolio Website
-// Version: 1.1.0
+// Version: 1.2.0
 // Caches resources for offline functionality with optimized cache lifetimes
 
-const CACHE_NAME = 'portfolio-cache-v1.1';
-const STATIC_CACHE_NAME = 'portfolio-static-v1.1';
-const DYNAMIC_CACHE_NAME = 'portfolio-dynamic-v1.1';
+const CACHE_NAME = 'portfolio-cache-v1.2';
+const STATIC_CACHE_NAME = 'portfolio-static-v1.2';
+const DYNAMIC_CACHE_NAME = 'portfolio-dynamic-v1.2';
 
 // Cache lifetime constants (in milliseconds)
 const STATIC_CACHE_MAX_AGE = 365 * 24 * 60 * 60 * 1000; // 1 year for static assets
@@ -135,8 +135,11 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // Handle different types of requests
-  if (isStaticAsset(request)) {
+  // SEO files must bypass the HTML handler — browser navigation sends
+  // Accept: text/html, which would otherwise route sitemap.xml to index.html fallback.
+  if (isSeoFile(request)) {
+    event.respondWith(handleSeoFile(request));
+  } else if (isStaticAsset(request)) {
     event.respondWith(handleStaticAsset(request));
   } else if (isAPIRequest(request)) {
     event.respondWith(handleAPIRequest(request));
@@ -162,7 +165,16 @@ function isAPIRequest(request) {
   return url.pathname.startsWith('/api/') || url.hostname.includes('api');
 }
 
+function isSeoFile(request) {
+  const url = new URL(request.url);
+  return /\.(xml|txt)$/.test(url.pathname);
+}
+
 function isHTMLRequest(request) {
+  if (isSeoFile(request)) {
+    return false;
+  }
+
   return request.headers.get('accept')?.includes('text/html');
 }
 
@@ -335,6 +347,29 @@ async function handleAPIRequest(request) {
       status: 503,
       statusText: 'Service Unavailable',
       headers: { 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+async function handleSeoFile(request) {
+  try {
+    const networkResponse = await fetch(request);
+    if (networkResponse.ok) {
+      const cache = await caches.open(STATIC_CACHE_NAME);
+      cache.put(request, networkResponse.clone());
+    }
+    return networkResponse;
+  } catch (error) {
+    const cache = await caches.open(STATIC_CACHE_NAME);
+    const cachedResponse = await cache.match(request);
+
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    return new Response('Offline - SEO file not available', {
+      status: 503,
+      statusText: 'Service Unavailable'
     });
   }
 }

--- a/tests/unit/ServiceWorker.spec.js
+++ b/tests/unit/ServiceWorker.spec.js
@@ -190,7 +190,16 @@ function isAPIRequest(request) {
   return url.pathname.startsWith('/api/') || url.hostname.includes('api');
 }
 
+function isSeoFile(request) {
+  const url = new URL(request.url);
+  return /\.(xml|txt)$/.test(url.pathname);
+}
+
 function isHTMLRequest(request) {
+  if (isSeoFile(request)) {
+    return false;
+  }
+
   return request.headers.get('accept')?.includes('text/html');
 }
 
@@ -297,6 +306,7 @@ async function handleStaticAsset(request) {
 // Export functions for testing
 self.testExports = {
   isStaticAsset,
+  isSeoFile,
   isAPIRequest,
   isHTMLRequest,
   isImageRequest,
@@ -378,9 +388,23 @@ describe('Service Worker', () => {
       const jsonRequest = new Request('http://localhost:8080/api', {
         headers: { 'accept': 'application/json' }
       })
+      const sitemapRequest = new Request('http://localhost:8080/portafolio/sitemap.xml', {
+        headers: { 'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' }
+      })
 
       expect(self.testExports.isHTMLRequest(htmlRequest)).toBe(true)
       expect(self.testExports.isHTMLRequest(jsonRequest)).toBe(false)
+      expect(self.testExports.isHTMLRequest(sitemapRequest)).toBe(false)
+    })
+
+    it('should identify SEO files correctly', () => {
+      const sitemapRequest = new Request('http://localhost:8080/portafolio/sitemap.xml')
+      const robotsRequest = new Request('http://localhost:8080/portafolio/robots.txt')
+      const htmlRequest = new Request('http://localhost:8080/index.html')
+
+      expect(self.testExports.isSeoFile(sitemapRequest)).toBe(true)
+      expect(self.testExports.isSeoFile(robotsRequest)).toBe(true)
+      expect(self.testExports.isSeoFile(htmlRequest)).toBe(false)
     })
 
     it('should identify image requests correctly', () => {


### PR DESCRIPTION
## Summary

Google Search Console reported "Couldn't fetch" for `/sitemap.xml`, and Chrome showed only plain text instead of XML. The file itself was valid; the service worker routed navigations (which send `Accept: text/html`) through the HTML handler and could serve `index.html` instead of the real sitemap.

- Route `.xml` / `.txt` SEO files through a dedicated network-first handler before the HTML path
- Bump service worker cache to `v1.2` so stale responses are cleared
- Refresh sitemap `lastmod` and add unit coverage for SEO file detection

## Changes Made

- `public/sw.js` — `isSeoFile`, `handleSeoFile`, cache version bump
- `public/sitemap.xml` — updated `lastmod`
- `tests/unit/ServiceWorker.spec.js` — SEO file / HTML Accept edge cases

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Tested locally
- [x] Added unit tests

### Test Steps

1. `npm run test:run -- tests/unit/ServiceWorker.spec.js`
2. After deploy: unregister SW, hard-refresh, open `/portafolio/sitemap.xml` — should show XML tree
3. Resubmit sitemap in Google Search Console

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

After merge, run `npm run deploy` so GitHub Pages serves the updated SW + sitemap.

Made with [Cursor](https://cursor.com)